### PR TITLE
Added quick fix which should allow the model to run only the single-i…

### DIFF
--- a/pywFM/__init__.py
+++ b/pywFM/__init__.py
@@ -259,7 +259,10 @@ class FM:
                 elif out_iter == 1:
                     weights.append(float(line))
                 elif out_iter == 2:
-                    pairwise_interactions.append([float(x) for x in line.split(' ')])
+                    try:
+                        pairwise_interactions.append([float(x) for x in line.split(' ')])
+                    except ValueError as e:
+                        pairwise_interactions.append(0.0) #Case: no pairwise interactions used
 
         pairwise_interactions = np.matrix(pairwise_interactions)
 


### PR DESCRIPTION
If the user sets the number of two-way interactions to 0, the model output file used by the wrapper outputs blanks under the pairwise interaction label. Under the current version, this raises a ValueError in the wrapper because wrapper assumes there will always be a compatible float following the two-way interaction header. 

I added a quick fix which catches this ValueError and sets the two-way interactions to 0 if an incompatible (non-numerical) value is parsed. This allows users to input the number of two-way interactions (k2) as 0, which is useful for running the one-way or global-bias models as a baseline. 
This is more closely inline with the libfm Binary input behavior, which, when the number of two-way interactions is set to 0, models only the global or one-way biases. 

There may be a way to handle the k2 input as 0 earlier in the setup phase of the wrapper, but this fix works. Catching the exception as a ValueError may create issues if for some reason the temporary model output file outputs other incompatible values which don't appear as a result of the user inputting 0 for k2.